### PR TITLE
Fix PEP8 warning

### DIFF
--- a/remote_ikernel/kernel.py
+++ b/remote_ikernel/kernel.py
@@ -356,7 +356,7 @@ class RemoteIKernel(object):
 
         # hostnames whould be alphanumeric with . and - permitted
         # This way we also ignore the echoed echo command
-        qsub_i.expect("Running on ([\w.-]+)")
+        qsub_i.expect(r"Running on ([\w.-]+)")
         node = qsub_i.match.groups()[0]
 
         self.log.info("Established session on node: {0}.".format(node))


### PR DESCRIPTION
(similar to https://stackoverflow.com/questions/19030952/pep8-warning-on-regex-string-in-python-eclipse)