### PR TITLE
Fixes for windows clients

### DIFF
--- a/remote_ikernel/kernel.py
+++ b/remote_ikernel/kernel.py
@@ -520,6 +520,7 @@ class RemoteIKernel(object):
         # connection info should have the ports being used
         tunnel_command = self.tunnel_cmd.format(**self.connection_info)
         tunnel = pexpect_spawn(tunnel_command, logfile=self.log)
+        tunnel.linesep = "\n"
         check_password(tunnel)
 
         self.log.info(
@@ -606,6 +607,7 @@ class RemoteIKernel(object):
         """
         if self.connection is None:
             self.connection = pexpect_spawn(command, timeout=timeout, logfile=self.log)
+            self.connection.linesep = "\n"
         else:
             self.connection.sendline(command)
 


### PR DESCRIPTION
This contains 2 small but important changes for windows clients.

1. The connection needs to use `\n` as the newline character to work with Linux servers; otherwise basically every command fails and the kernel never starts. (The Windows-to-Linux case is the only one I have tested.)
2. The `PopenSpawn` object does not come with a `sendintr` method, but it does have `kill` which can send any signal. This adds `sendintr` in the adapter object to restore the functionality of killing the kernel when the jupyter-lab process is interrupted.